### PR TITLE
AEIM-1178 - Remove mysql2 and auto-config for database

### DIFF
--- a/checkpoint.gemspec
+++ b/checkpoint.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ettin", "~> 1.1"
-  spec.add_dependency "mysql2", "~> 0.4.10"
   spec.add_dependency "sequel", "~> 5.6"
 
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/lib/checkpoint.rb
+++ b/lib/checkpoint.rb
@@ -3,7 +3,6 @@
 require "checkpoint/version"
 
 require 'sequel'
-require 'mysql2'
 require 'ettin'
 
 # All of the Checkpoint components are contained within this top-level module.

--- a/lib/checkpoint/railtie.rb
+++ b/lib/checkpoint/railtie.rb
@@ -66,9 +66,14 @@ module Checkpoint
     initializer "checkpoint.before_initializers", before: :load_config_initializers do
       config = Checkpoint::DB.config
       unless config.url
-        opts = ActiveRecord::Base.connection.instance_variable_get(:@config).dup
-        opts.delete(:flags)
-        config[:opts] = opts
+        case Rails.env
+        when "development"
+          config[:opts] = { adapter: 'sqlite', database: 'db/checkpoint_development.sqlite3' }
+        when "test"
+          config[:opts] = { adapter: 'sqlite' }
+        else
+          raise "Checkpoint::DB.config must be configured."
+        end
       end
 
       Railtie.before_blocks.each do |block|


### PR DESCRIPTION
This follows the change applied to Keycard, removing the mysql2 gem
dependency and the automatic configuration that tries to use the
database from ActiveRecord. This was more trouble than it was worth.