### PR TITLE
CP-53 - Add convenient methods for testing Resource wildcards

### DIFF
--- a/lib/checkpoint/resource.rb
+++ b/lib/checkpoint/resource.rb
@@ -54,6 +54,14 @@ module Checkpoint
       AllOfAnyType.new
     end
 
+    # Test whether this Resource represents all entities of all types.
+    #
+    # @see {::all}
+    # @return [Boolean] true if this is a universal wildcard
+    def all?
+      type == ALL && id == ALL
+    end
+
     # Convert this object to a Resource.
     #
     # For Checkpoint-supplied Resources, this is an identity operation,
@@ -115,6 +123,14 @@ module Checkpoint
     # @return [Resource] A Resource of the same type, but for all members
     def all_of_type
       Resource::AllOfType.new(type)
+    end
+
+    # Test whether this is a Resource wildcard of some specific type.
+    #
+    # @return [Boolean] true if this Resource has a specific type, but
+    #   has the any/all ID, representing any Resources of that type
+    def all_of_type?
+      type != ALL && id == ALL
     end
 
     # Check whether two Resources refer to the same entity.

--- a/lib/checkpoint/resource/token.rb
+++ b/lib/checkpoint/resource/token.rb
@@ -37,6 +37,21 @@ module Checkpoint
         @all ||= new(Resource::ALL, Resource::ALL).freeze
       end
 
+      # Test whether this token is for the special "all" Resource.
+      #
+      # @return [Boolean] true if this token represents any/all resources
+      def all?
+        type == Resource::ALL && id == Resource::ALL
+      end
+
+      # Test whether this token is a wildcard for some specific type.
+      #
+      # @return [Boolean] true if this token has a specific type, but
+      #   represents any/all resources of that type
+      def all_of_type?
+        type != Resource::ALL && id == Resource::ALL
+      end
+
       # @return [Token] self; for convenience of taking a Resource or token
       def token
         self

--- a/spec/checkpoint/resource/token_spec.rb
+++ b/spec/checkpoint/resource/token_spec.rb
@@ -65,6 +65,52 @@ module Checkpoint
       end
     end
 
+    describe "#all?" do
+      context 'for the "all" resource' do
+        it "is true" do
+          token = described_class.all
+          expect(token.all?).to eq true
+        end
+      end
+
+      context 'for a type wildcard' do
+        it "is false" do
+          token = described_class.new('some-type', Checkpoint::Resource::ALL)
+          expect(token.all?).to eq false
+        end
+      end
+
+      context 'for a specific resource' do
+        it "is false" do
+          token = described_class.new('some-type', 'some-id')
+          expect(token.all?).to eq false
+        end
+      end
+    end
+
+    describe "#all_of_type?" do
+      context 'for the "all" resource' do
+        it "is false" do
+          token = described_class.all
+          expect(token.all_of_type?).to eq false
+        end
+      end
+
+      context 'for a type wildcard' do
+        it "is true" do
+          token = described_class.new('some-type', Checkpoint::Resource::ALL)
+          expect(token.all_of_type?).to eq true
+        end
+      end
+
+      context 'for a specific resource' do
+        it "is false" do
+          token = described_class.new('some-type', 'some-id')
+          expect(token.all_of_type?).to eq false
+        end
+      end
+    end
+
     describe "#eql?" do
       it 'considers resources as the same if type and id match' do
         res1 = described_class.new('some-type', 'some-id')

--- a/spec/checkpoint/resource_spec.rb
+++ b/spec/checkpoint/resource_spec.rb
@@ -79,6 +79,58 @@ RSpec.describe Checkpoint::Resource do
     end
   end
 
+  describe "#all?" do
+    let(:entity) { double('Entity', type: 'type', id: 'id') }
+
+    context 'for the "all" resource' do
+      it "is true" do
+        resource = described_class.all
+        expect(resource.all?).to eq true
+      end
+    end
+
+    context 'for a type wildcard' do
+      it "is false" do
+        resource = described_class.new(entity).all_of_type
+        expect(resource.all?).to eq false
+      end
+    end
+
+    context 'for a specific resource' do
+      it "is false" do
+        resource = described_class.new(entity)
+        expect(resource.all?).to eq false
+      end
+    end
+  end
+
+  describe "#all_of_type?" do
+    context 'for the "all" resource' do
+      it "is false" do
+        token = described_class.all
+        expect(token.all_of_type?).to eq false
+      end
+    end
+
+    context 'for a type wildcard' do
+      let(:entity) { double('Entity', type: 'type', id: 'id') }
+
+      it "is true" do
+        token = described_class.new(entity).all_of_type
+        expect(token.all_of_type?).to eq true
+      end
+    end
+
+    context 'for a specific resource' do
+      let(:entity) { double('Entity', type: 'type', id: 'id') }
+
+      it "is false" do
+        token = described_class.new(entity)
+        expect(token.all_of_type?).to eq false
+      end
+    end
+  end
+
   # @botimer - 2018-02-26: I'm of two minds on this kind of test. There is an
   # argument that including some kind of realistic example (say, a Document
   # type) helps clarify expected usage. There is also an argument that this is


### PR DESCRIPTION
The #all? and #all_of_type? methods on Resource and Resource::Token make
it easy to check whether or not the object held is a wildcard for all
entities of a type or all of any type. The predicate methods use the
same base names as those used to create wildcards from entities.