### PR TITLE
CP-54 - Add aliases so tokens can convert and be granted

### DIFF
--- a/lib/checkpoint/agent/token.rb
+++ b/lib/checkpoint/agent/token.rb
@@ -52,6 +52,8 @@ module Checkpoint
 
       alias == eql?
       alias inspect uri
+      alias agent_id id
+      alias agent_type type
     end
   end
 end

--- a/lib/checkpoint/credential/token.rb
+++ b/lib/checkpoint/credential/token.rb
@@ -51,6 +51,8 @@ module Checkpoint
 
       alias == eql?
       alias inspect uri
+      alias credential_type type
+      alias credential_id id
     end
   end
 end

--- a/lib/checkpoint/resource/token.rb
+++ b/lib/checkpoint/resource/token.rb
@@ -80,6 +80,8 @@ module Checkpoint
 
       alias == eql?
       alias inspect uri
+      alias resource_type type
+      alias resource_id id
     end
   end
 end

--- a/spec/checkpoint/agent/token_spec.rb
+++ b/spec/checkpoint/agent/token_spec.rb
@@ -14,6 +14,14 @@ module Checkpoint
       expect(agent.id).to eq('an_id')
     end
 
+    it 'aliases agent_type and type' do
+      expect(agent.agent_type).to eq(agent.type)
+    end
+
+    it 'aliases agent_id and id' do
+      expect(agent.agent_id).to eq(agent.id)
+    end
+
     context 'when given non-string inputs' do
       subject(:agent) { described_class.new(Object, 1) }
 

--- a/spec/checkpoint/credential/token_spec.rb
+++ b/spec/checkpoint/credential/token_spec.rb
@@ -14,6 +14,14 @@ module Checkpoint
       expect(credential.id).to eq('an_id')
     end
 
+    it 'aliases credential_type and type' do
+      expect(credential.credential_type).to eq(credential.type)
+    end
+
+    it 'aliases credential_id and id' do
+      expect(credential.credential_id).to eq(credential.id)
+    end
+
     context 'when given non-string inputs' do
       subject(:credential) { described_class.new(Object, 1) }
 

--- a/spec/checkpoint/resource/token_spec.rb
+++ b/spec/checkpoint/resource/token_spec.rb
@@ -14,6 +14,14 @@ module Checkpoint
       expect(resource.id).to eq('an_id')
     end
 
+    it 'aliases resource_type and type' do
+      expect(resource.resource_type).to eq(resource.type)
+    end
+
+    it 'aliases resource_id and id' do
+      expect(resource.resource_id).to eq(resource.id)
+    end
+
     context 'when given non-string inputs' do
       subject(:resource) { described_class.new(Object, 1) }
 


### PR DESCRIPTION
At some point, we stopped calling #type for conversion, which I think is
still probably correct. This change adds type-specific aliases like
agent_type to type on Agent::Token so the tokens can be granted without
having a reference to the real entity. This is the reason they were
separated off in the first place, so this was just a plain-old bug.